### PR TITLE
Improve local development experience on macOS

### DIFF
--- a/dl-downer/.gitignore
+++ b/dl-downer/.gitignore
@@ -3,3 +3,4 @@ downloads
 storage_states
 cdm
 __pycache__
+.venv

--- a/dl-queue/package-lock.json
+++ b/dl-queue/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1",
-        "body-parser": "^1.20.2",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",

--- a/dl-queue/package.json
+++ b/dl-queue/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "base64-js": "^1.5.1",
-    "body-parser": "^1.20.2",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-async-handler": "^1.2.0",

--- a/dl-queue/src/index.ts
+++ b/dl-queue/src/index.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import { config } from 'dotenv';
-import bodyParser from 'body-parser';
 import expressAsyncHandler from 'express-async-handler';
 import { getQueueHandler } from './handlers/get-queue';
 import { postQueueAddHandler } from './handlers/post-queue-add';
@@ -38,7 +37,7 @@ testDatabaseConnection().then(() => {
 });
 
 const app = express();
-app.use(bodyParser.json());
+app.use(express.json());
 const port = process.env.PORT || 3000;
 
 app.use((req, res, next) => {


### PR DESCRIPTION
Back when the Streamz integration was originally added, getting everything to run smoothly on my Mac took quite a bit of trial and error. Since then my local copy has diverged significantly from this repository. I would like to start aligning things again, while making sure we do not introduce regressions for others using different setups.

This PR is one small step in that process. With these changes in place, I am now able to start both the queue service and the Python downloader locally again.

This PR contains a few small, safe changes to make local development more predictable:

- Ignore `.venv` so local virtual environments do not get picked up accidentally.
- Replace `body-parser` usage with `express.json()`, which is the built in and recommended approach in modern Express.
- Remove the explicit body-parser dependency to reduce unnecessary packages.

At the moment the Python downloader still reports a read only filesystem issue. I will investigate that over the next days. If fixes are required, I will open a follow up PR.

No functional behavior should change. This is mainly cleanup and modernization to make running the project locally easier and more consistent across environments.

Happy to adjust if this impacts anyone’s workflow.