### PR TITLE
feat: output filename pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ Currently supported content providers:
 
 Python script that monitors a database table for new download requests, if a new request is found the script does its best to download (and decrypt) the video (using a local CDM).
 
+<details>
+<summary>Environment variables</summary>
+
+| Variable | Description |
+|---|---|
+| `DOWNLOADS_FOLDER` | Where downloaded files are stored (default: `./downloads`) |
+| `STORAGE_STATES_FOLDER` | Playwright auth storage states (default: `./storage_states`) |
+| `CDM_FILE_PATH` | Path to the Widevine `.wvd` CDM file (default: `./cdm/cdm.wvd`) |
+| `AUTH_<PLATFORM>_EMAIL` / `_PASSWORD` | Credentials per platform (`VRTMAX`, `GOPLAY`, `VTMGO`, `STREAMZ`) |
+| `DL_OUTPUT_PATTERN` | Output filename pattern (default: `{platform}/{title}.S{season}E{episode}.{extension}`) e.g. PLEX friendly pattern: `{title_spaced}/Season {season}/{title_spaced} S{season}E{episode}.{extension}` |
+| `DL_GOPLAY_MERGE_METHOD` | DANGER (only change when certain): GoPlay stream merge method — `period` or `format` (default: `format`) |
+| `HEADLESS` | DANGER (only change when certain): Run browser in headless mode (default: `true`) |
+
+</details>
+
 ### Troubleshooting
 
 If you encouter issues with the login for VTM GO, you might need to create a storage state by turning off `HEADLESS` mode via the env variable. (You might need to do this on another machine as non-headless might not be supported in the current environment)

--- a/dl-downer/Dockerfile
+++ b/dl-downer/Dockerfile
@@ -27,8 +27,7 @@ ENV AUTH_STREAMZ_EMAIL=
 ENV AUTH_STREAMZ_PASSWORD=
 
 ENV DL_GOPLAY_MERGE_METHOD=period
-# Default set in code
-ENV DL_OUTPUT_PATTERN={platform}/{title}.S{season}E{episode}.{extension} 
+ENV DL_OUTPUT_PATTERN=
 
 ENV PUID=6969
 ENV PGID=6969

--- a/dl-downer/Dockerfile
+++ b/dl-downer/Dockerfile
@@ -27,6 +27,8 @@ ENV AUTH_STREAMZ_EMAIL=
 ENV AUTH_STREAMZ_PASSWORD=
 
 ENV DL_GOPLAY_MERGE_METHOD=period
+# Default set in code
+ENV DL_OUTPUT_PATTERN={platform}/{title}.S{season}E{episode}.{extension} 
 
 ENV PUID=6969
 ENV PGID=6969

--- a/dl-downer/cli.py
+++ b/dl-downer/cli.py
@@ -9,10 +9,14 @@ os.environ["AUTH_VTMGO_PASSWORD"] = ""
 os.environ["AUTH_STREAMZ_EMAIL"] = ""
 os.environ["AUTH_STREAMZ_PASSWORD"] = ""
 
-
 os.environ["CDM_FILE_PATH"] = "./cdm/cdm.wvd"
 os.environ["STORAGE_STATES_FOLDER"] = "./storage_states"
 os.environ["DOWNLOADS_FOLDER"] = "./downloads"
+
+#default
+os.environ["DL_OUTPUT_PATTERN"] = "{platform}/{title}.S{season}E{episode}.{extension}"
+# automatic PLEX friendly pattern (uncomment to use)
+# os.environ["DL_OUTPUT_PATTERN"] = "{title_spaced}/Season {season}/{title_spaced} S{season}E{episode}.{extension}"
 
 # Do not touch if unsure
 os.environ["DL_GOPLAY_MERGE_METHOD"] = "format"

--- a/dl-downer/src/downloaders/GENERIC_MANIFEST.py
+++ b/dl-downer/src/downloaders/GENERIC_MANIFEST.py
@@ -1,17 +1,25 @@
 import time
 
 from ..utils.download_video_nre import download_video_nre
+from ..utils.filename import parse_filename
 from ..models.dl_request_platform import DLRequestPlatform
 from ..models.dl_request import DLRequest
+from ..models.download_result import DownloadResult
 
-def GENERIC_MANIFEST_DL(dl_request: DLRequest):
-  filename = time.strftime('%Y%m%d-%H%M%S')
-  if dl_request.output_filename:
-    filename = dl_request.output_filename
+def GENERIC_MANIFEST_DL(dl_request: DLRequest) -> DownloadResult:
+  title = dl_request.output_filename if dl_request.output_filename else time.strftime('%Y%m%d-%H%M%S')
 
-  download_video_nre(
+  downloaded_file = download_video_nre(
     dl_request.video_page_or_manifest_url,
-    filename,
+    parse_filename(title),
     DLRequestPlatform.GENERIC_MANIFEST,
     dl_request.preferred_quality_matcher,
+  )
+
+  return DownloadResult(
+    file_path=downloaded_file,
+    title=title,
+    platform=DLRequestPlatform.GENERIC_MANIFEST.value,
+    extension='mkv',
+    suggested_filepath=downloaded_file,
   )

--- a/dl-downer/src/downloaders/GOPLAY.py
+++ b/dl-downer/src/downloaders/GOPLAY.py
@@ -160,7 +160,7 @@ def GOPLAY_DL(dl_request: DLRequest) -> DownloadResult:
   script_tag = re.search(r'<script>(?:(?!</?script>).)*playerContainer(?:(?!</?script>).)*</script>', page_content)
   if script_tag is None:
     logger.error('No video data found')
-    return
+    raise RuntimeError('No video data found in GOPLAY page')
   script_tag_str = script_tag.group(0)
 
   video_uuid = re.search(r'\\"videoId\\":\\"([^"]+?)\\"', script_tag_str).group(1)

--- a/dl-downer/src/downloaders/GOPLAY.py
+++ b/dl-downer/src/downloaders/GOPLAY.py
@@ -1,7 +1,6 @@
 import json
 import re
 import os
-import shutil
 import requests
 
 from loguru import logger
@@ -13,9 +12,11 @@ from ..utils.browser import create_playwright_page, get_storage_state_location
 from ..utils.download_video_nre import download_subs_nre
 from ..utils.local_cdm import Local_CDM
 from ..utils.filename import parse_filename
+from ..utils.parse_filename_fields import parse_filename_fields
 from ..utils.files import insert_subtitle
 from ..models.dl_request_platform import DLRequestPlatform
 from ..models.dl_request import DLRequest
+from ..models.download_result import DownloadResult
 
 def handle_goplay_consent_popup(page):
   '''
@@ -151,7 +152,7 @@ def get_stream_manifest_and_keys(type_form: str, video_uuid: str, is_drm: bool) 
   return stream_manifest, keys
 
 
-def GOPLAY_DL(dl_request: DLRequest):
+def GOPLAY_DL(dl_request: DLRequest) -> DownloadResult:
   # Parse video uuid from the page
   page_resp = requests.get(dl_request.video_page_or_manifest_url)
   page_content = page_resp.text
@@ -194,17 +195,9 @@ def GOPLAY_DL(dl_request: DLRequest):
   download_options.merge_method = merge_method
   # download the mpd
   final_file = mpd.download('./tmp', download_options)
-  # move the final file to the downloads folder
-  final_file_move_to = dl_request.get_full_filename_path(title, extension=os.path.splitext(final_file)[1][1:])
-  # Make sure the folder exists
-  os.makedirs(os.path.dirname(final_file_move_to), exist_ok=True)
-  # We can't use shutil.move or os.rename because the destination
-  # might be on a different filesystem depending on the configuration
-  shutil.copy(final_file, final_file_move_to)
-  os.remove(final_file)
-  logger.debug(f'Downloaded {title} to {final_file_move_to}')
+  extension = os.path.splitext(final_file)[1][1:]
 
-    # Attempt to download subtitles if any
+  # Download and insert subtitles while still in tmp location
   downloaded_subs = download_subs_nre(
     mpd_url=stream_manifest,
     filename=title,
@@ -213,9 +206,18 @@ def GOPLAY_DL(dl_request: DLRequest):
   )
   # if downloaded subs, insert them into the video file and remove them
   for sub in downloaded_subs:
-    insert_subtitle(
-      input_file=final_file_move_to,
-      subtitle_file=sub,
-    )
+    insert_subtitle(input_file=final_file, subtitle_file=sub)
     os.remove(sub)
+
+  parsed = parse_filename_fields(title)
+
+  return DownloadResult(
+    file_path=final_file,
+    title=parsed['title'],
+    platform=DLRequestPlatform.GOPLAY.value,
+    extension=extension,
+    suggested_filepath=dl_request.get_full_filename_path(title, extension=os.path.splitext(final_file)[1][1:]),
+    season=parsed['season'],
+    episode=parsed['episode'],
+  )
     

--- a/dl-downer/src/downloaders/GOPLAY.py
+++ b/dl-downer/src/downloaders/GOPLAY.py
@@ -171,7 +171,7 @@ def GOPLAY_DL(dl_request: DLRequest) -> DownloadResult:
     title = re.search(r'\\"title\\":\\"([^"]+?)\\"', script_tag_str).group(1)
     title = parse_filename(title)
   else:
-    title = dl_request.output_filename
+    title = parse_filename(dl_request.output_filename)
 
   logger.debug(f'Video uuid: {video_uuid}')
   logger.debug(f'Type: {type_form}')

--- a/dl-downer/src/downloaders/VRTMAX.py
+++ b/dl-downer/src/downloaders/VRTMAX.py
@@ -1,20 +1,15 @@
 import base64
-import hashlib
-import hmac
 import json
 import re
 import os
-import shutil
 import requests
-import time
 from loguru import logger
 from urllib.parse import urlparse
 
 from ..pssh_box import pssh_box
-from ..mpd.mpd import MPD
-from ..mpd.mpd_download_options import MPDDownloadOptions
 from ..models.dl_request_platform import DLRequestPlatform
 from ..models.dl_request import DLRequest
+from ..models.download_result import DownloadResult
 from ..utils.filename import parse_filename
 from ..utils.local_cdm import Local_CDM
 from ..utils.download_video_nre import download_video_nre
@@ -97,7 +92,7 @@ def get_graphql_metadata(url_path, cookies):
   '''
   Get video metadata from GraphQL API
 
-  :return: tuple of program title, name, and stream_id
+  :return: tuple of (program_title, season, episode, stream_id)
   '''
   json_data = {
     'query': VRTMAX_graphql_query,
@@ -154,18 +149,12 @@ def get_graphql_metadata(url_path, cookies):
     if regex_result:
       episode = regex_result.group(1).zfill(2)
 
-  if season and episode:
-    title = f'{program_title} S{season}E{episode}' # should always occur for series
-  else:
-    title = program_title # usually occurs for movies
-  logger.debug(f'Title: {title}')
-
   stream_id = body['data']['page']['player']['modes'][0]['streamId']
   logger.debug(f'Stream ID: {stream_id}')
   if not stream_id:
     raise Exception('Stream ID not found in GraphQL response')
 
-  return (title, stream_id)
+  return (program_title, season, episode, stream_id)
 
 def get_video_token(vrt_token, player_info):
   '''
@@ -263,7 +252,7 @@ def get_pssh_box(mpd_url: str) -> str:
   ], force_protection_scheme=True)
   return pssh
 
-def VRTMAX_DL(dl_request: DLRequest):
+def VRTMAX_DL(dl_request: DLRequest) -> DownloadResult:
 
   url = dl_request.video_page_or_manifest_url
   url_path = urlparse(url).path.rstrip('/')
@@ -273,14 +262,16 @@ def VRTMAX_DL(dl_request: DLRequest):
   # Transform List[Cookies] into RequestsCookieJar
   cookies = requests.utils.cookiejar_from_dict({c['name']:c['value'] for c in cookies})
 
-  title, stream_id = get_graphql_metadata(url_path, cookies)
+  program_title, season, episode, stream_id = get_graphql_metadata(url_path, cookies)
   video_token = get_video_token(vrt_token, '')
   drm_token, mpd_url = get_video_metadata(stream_id, video_token)
 
-  filename = dl_request.output_filename
-  if not filename:
-    filename = parse_filename(title)
-  logger.debug(f'Filename: {filename}')
+  title = dl_request.output_filename if dl_request.output_filename else program_title
+  # Build intermediate filename for the download tool
+  intermediate_filename = parse_filename(
+    f'{title}.S{season}E{episode}' if season and episode else title
+  )
+  logger.debug(f'Filename: {intermediate_filename}')
 
   # retrieve the keys if DRM
   keys = {}
@@ -295,25 +286,20 @@ def VRTMAX_DL(dl_request: DLRequest):
     myCDM.close()
 
   # download the video
-  download_video_nre(
+  downloaded_file = download_video_nre(
     mpd_url,
-    filename,
+    intermediate_filename,
     DLRequestPlatform.VRTMAX,
     dl_request.preferred_quality_matcher,
     keys=keys,
   )
-  return
-  # ---------- Using own MPD downloader ----------
-  # initalize mpd object
-  mpd = MPD.from_url(mpd_url)
-  download_options = MPDDownloadOptions()
-  if dl_request.preferred_quality_matcher:
-    download_options.video_resolution = dl_request.preferred_quality_matcher
-  if len(keys) > 0:
-    download_options.keys = keys
-  logger.debug('No DRM detected, downloading without decryption')
-  final_file = mpd.download('./tmp', download_options)
-  # move the final file to the downloads folder
-  final_file_move_to = dl_request.get_full_filename_path(filename)
-  shutil.move(final_file, final_file_move_to)
-  logger.debug(f'Downloaded {filename} to {final_file_move_to}')
+
+  return DownloadResult(
+    file_path=downloaded_file,
+    title=title,
+    platform=DLRequestPlatform.VRTMAX.value,
+    extension='mkv',
+    suggested_filepath=downloaded_file,
+    season=season,
+    episode=episode,
+  )

--- a/dl-downer/src/downloaders/VTMGO.py
+++ b/dl-downer/src/downloaders/VTMGO.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from ..models.dl_request import DLRequest
 from ..models.dl_request_platform import DLRequestPlatform
+from ..models.download_result import DownloadResult
 from ..utils.download_video_nre import download_video_nre
 from ..utils.local_cdm import Local_CDM
 from ..utils.filename import parse_filename
@@ -110,6 +111,22 @@ def extract_dash_stream_info(config) -> dict:
     'auth_token': dash_stream['drm']['com.widevine.alpha']['drmtoday']['authToken'],
   }
 
+def extract_metadata_fields(config, output_filename=None):
+  """Extract title, season, episode from config metadata."""
+  if output_filename:
+    return output_filename, None, None
+
+  metadata = config['video']['metadata']
+  if 'episode' not in metadata:
+    return metadata['title'], None, None
+
+  ep_order = metadata['episode'].get('order')
+  ep = str(ep_order if ep_order is not None else 0).zfill(2)
+  season = str(metadata['episode']['season']['order']).zfill(2)
+  title = metadata['program']['title']
+  return title, season, ep
+
+# Deprecated: use extract_metadata_fields instead
 def generate_filename_from_metadata(config, output_filename=None):
   """Generate filename from metadata or use provided filename"""
   if output_filename:
@@ -198,7 +215,7 @@ def download_and_insert_subtitles(config, downloaded_file, preferred_lang='nl-tt
   insert_subtitle(downloaded_file, subtitle_filename)
   os.remove(subtitle_filename)
 
-def process_dpg_media_download(config, dl_request, platform, origin_url='https://www.vtmgo.be'):
+def process_dpg_media_download(config, dl_request, platform, origin_url='https://www.vtmgo.be') -> DownloadResult:
   """
   Common download logic for DPG Media platforms (VTMGO, STREAMZ)
   This can be called from both VTMGO_DL and STREAMZ_DL functions
@@ -213,9 +230,15 @@ def process_dpg_media_download(config, dl_request, platform, origin_url='https:/
   logger.debug(f'License: {license_url}')
   logger.debug(f'Auth token: {auth_token}')
 
-  # Generate filename
-  filename = generate_filename_from_metadata(config, dl_request.output_filename)
-  logger.debug(f'Filename: {filename}')
+  # Extract metadata fields separately
+  title, season, episode = extract_metadata_fields(config, dl_request.output_filename)
+
+  # Build intermediate filename for download_video_nre
+  if season and episode:
+    intermediate_filename = parse_filename(f'{title}.S{season}E{episode}')
+  else:
+    intermediate_filename = parse_filename(title)
+  logger.debug(f'Filename: {intermediate_filename}')
 
   # Get PSSH and keys
   pssh = get_pssh_from_manifest(mpd_url)
@@ -227,17 +250,25 @@ def process_dpg_media_download(config, dl_request, platform, origin_url='https:/
   # Download video
   downloaded_file = download_video_nre(
     mpd_url,
-    filename,
+    intermediate_filename,
     platform,
     dl_request.preferred_quality_matcher,
     keys=keys,
   )
 
-  # Handle subtitles
+  # Handle subtitles on the intermediate file (before the central move)
   download_and_insert_subtitles(config, downloaded_file)
 
-  return downloaded_file
+  return DownloadResult(
+    file_path=downloaded_file,
+    title=title,
+    platform=platform.value,
+    extension='mkv',
+    suggested_filepath=downloaded_file,
+    season=season,
+    episode=episode,
+  )
 
-def VTMGO_DL(dl_request: DLRequest):
+def VTMGO_DL(dl_request: DLRequest) -> DownloadResult:
   config = get_vtmgo_data(dl_request.video_page_or_manifest_url)
   return process_dpg_media_download(config, dl_request, DLRequestPlatform.VTMGO)

--- a/dl-downer/src/downloaders/YOUTUBE.py
+++ b/dl-downer/src/downloaders/YOUTUBE.py
@@ -35,13 +35,23 @@ def YOUTUBE_DL(dl_request: DLRequest):
   command.extend([ '-o', file_path ])
   command.extend([ dl_request.video_page_or_manifest_url ])
 
+  # Use --print to capture the actual output filepath after merging
+  command.extend(['--print', 'after_move:filepath'])
+
   logger.debug(f'Running command: {command}')
-  subprocess.run(command)
+  proc = subprocess.run(command, capture_output=True, text=True)
+  logger.debug(f'yt-dlp stdout: {proc.stdout}')
+  if proc.stderr:
+    logger.debug(f'yt-dlp stderr: {proc.stderr}')
+
+  # The last non-empty line of stdout is the resolved filepath
+  resolved_path = proc.stdout.strip().splitlines()[-1].strip() if proc.stdout.strip() else file_path
+  title = os.path.splitext(os.path.basename(resolved_path))[0]
 
   return DownloadResult(
-    file_path=file_path,
-    title=filename.rsplit('.', 1)[0],
+    file_path=resolved_path,
+    title=title,
     platform=DLRequestPlatform.YOUTUBE.value,
     extension='mkv',
-    suggested_filepath=file_path,
+    suggested_filepath=resolved_path,
   )

--- a/dl-downer/src/downloaders/YOUTUBE.py
+++ b/dl-downer/src/downloaders/YOUTUBE.py
@@ -4,6 +4,8 @@ import subprocess
 from loguru import logger
 
 from ..models.dl_request import DLRequest
+from ..models.download_result import DownloadResult
+from ..models.dl_request_platform import DLRequestPlatform
 
 def YOUTUBE_DL(dl_request: DLRequest):
   
@@ -35,3 +37,11 @@ def YOUTUBE_DL(dl_request: DLRequest):
 
   logger.debug(f'Running command: {command}')
   subprocess.run(command)
+
+  return DownloadResult(
+    file_path=file_path,
+    title=filename.rsplit('.', 1)[0],
+    platform=DLRequestPlatform.YOUTUBE.value,
+    extension='mkv',
+    suggested_filepath=file_path,
+  )

--- a/dl-downer/src/models/dl_request.py
+++ b/dl-downer/src/models/dl_request.py
@@ -1,4 +1,5 @@
 import os
+
 from datetime import datetime
 
 from ..models.dl_request_status import DLRequestStatus
@@ -86,6 +87,7 @@ class DLRequest:
     self.status = new_status
     self.updated = datetime.now()
 
+  # Deprecated: superseded by apply_output_pattern
   def get_full_filename_path(
     self,
     filename: str,

--- a/dl-downer/src/models/download_result.py
+++ b/dl-downer/src/models/download_result.py
@@ -1,0 +1,20 @@
+class DownloadResult:
+  '''Standardized result returned by every platform downloader.'''
+
+  def __init__(
+    self,
+    file_path: str,
+    title: str,
+    platform: str,
+    extension: str,
+    suggested_filepath: str,
+    season: str = None,
+    episode: str = None,
+  ):
+    self.file_path = file_path
+    self.title = title
+    self.platform = platform
+    self.extension = extension
+    self.suggested_filepath = suggested_filepath
+    self.season = season
+    self.episode = episode

--- a/dl-downer/src/utils/apply_output_pattern.py
+++ b/dl-downer/src/utils/apply_output_pattern.py
@@ -1,0 +1,108 @@
+import os
+import re
+from datetime import datetime
+from loguru import logger
+from .filename import parse_filename
+
+
+DEFAULT_PATTERN = '{platform}/{title}.S{season}E{episode}.{extension}'
+
+
+def apply_output_pattern(
+  title: str,
+  platform: str,
+  extension: str,
+  suggested_filepath: str,
+  current_filepath: str = None,
+  season: str = None,
+  episode: str = None,
+) -> str:
+  '''
+  Build the final output file path by applying DL_OUTPUT_PATTERN.
+
+  The pattern is relative to DOWNLOADS_FOLDER. Segments containing
+  unresolved {variables} are stripped (e.g. .S{season}E{episode}
+  disappears when season/episode are None).
+
+  Falls back to suggested_filepath on pattern errors or path traversal.
+  '''
+  pattern = os.getenv('DL_OUTPUT_PATTERN', DEFAULT_PATTERN)
+
+  if '..' in pattern:
+    logger.warning(f'Path traversal in DL_OUTPUT_PATTERN: {pattern}. Using fallback.')
+    return suggested_filepath
+
+  sanitized_title = parse_filename(title)
+
+  variables = {
+    'platform': platform,
+    'title': sanitized_title,
+    'title_spaced': sanitized_title.replace('.', ' '),
+    'extension': extension,
+  }
+  if season is not None:
+    variables['season'] = season
+  if episode is not None:
+    variables['episode'] = episode
+
+  path_segments = pattern.split('/')
+  resolved_segments = []
+
+  for segment in path_segments:
+    resolved = _resolve_segment(segment, variables)
+    if resolved:
+      resolved_segments.append(resolved)
+
+  if not resolved_segments:
+    logger.warning(f'Pattern resolved to empty. Using fallback: {suggested_filepath}')
+    return suggested_filepath
+
+  downloads_folder = os.getenv('DOWNLOADS_FOLDER', './downloads')
+  relative_path = '/'.join(resolved_segments)
+  absolute_path = os.path.normpath(os.path.join(downloads_folder, relative_path))
+  absolute_downloads = os.path.normpath(os.path.abspath(downloads_folder))
+
+  # Ensure resolved path stays within DOWNLOADS_FOLDER
+  if not os.path.abspath(absolute_path).startswith(absolute_downloads):
+    logger.warning(f'Resolved path escapes DOWNLOADS_FOLDER. Using fallback: {suggested_filepath}')
+    return suggested_filepath
+
+  # If the file is already at the resolved location, return as-is (skip dedup)
+  if current_filepath and os.path.abspath(current_filepath) == os.path.abspath(absolute_path):
+    return absolute_path
+
+  # Deduplicate: append timestamp if file already exists
+  if os.path.exists(absolute_path):
+    name, ext = os.path.splitext(absolute_path)
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    absolute_path = f'{name}-{timestamp}{ext}'
+
+  logger.debug(f'Output pattern resolved: {pattern} -> {absolute_path}')
+  return absolute_path
+
+
+def _resolve_segment(segment: str, variables: dict) -> str:
+  '''
+  Resolve a path segment by splitting on '.' and dropping
+  dot-groups that still contain unresolved {placeholders}.
+  '''
+  dot_groups = segment.split('.')
+  resolved_groups = []
+
+  for group in dot_groups:
+    resolved = _substitute_variables(group, variables)
+    if re.search(r'\{[^}]+\}', resolved):
+      continue
+    if resolved:
+      resolved_groups.append(resolved)
+
+  return '.'.join(resolved_groups)
+
+
+def _substitute_variables(text: str, variables: dict) -> str:
+  '''Replace {key} placeholders with values from variables dict.'''
+  def replacer(match):
+    key = match.group(1)
+    return variables[key] if key in variables else match.group(0)
+
+  return re.sub(r'\{([^}]+)\}', replacer, text)

--- a/dl-downer/src/utils/download_dl_request.py
+++ b/dl-downer/src/utils/download_dl_request.py
@@ -38,6 +38,20 @@ def download_dl_request(
     logger.error(f'Unsupported platform: {dl_request.platform}')
     raise Exception('Unsupported platform')
 
+  # Validate downloader result before proceeding
+  if result is None:
+    logger.error(f'Downloader returned no result for platform: {dl_request.platform}')
+    raise RuntimeError('Download failed: no result returned from downloader')
+  if not isinstance(result, DownloadResult):
+    logger.error(f'Downloader returned unexpected result type for platform {dl_request.platform}: {type(result)}')
+    raise TypeError('Download failed: unexpected downloader result type')
+  if not getattr(result, 'file_path', None):
+    logger.error(f'DownloadResult missing file_path for platform: {dl_request.platform}')
+    raise ValueError('Download failed: missing file_path in downloader result')
+  if not os.path.exists(result.file_path):
+    logger.error(f'Downloaded file does not exist at expected path: {result.file_path}')
+    raise FileNotFoundError(f'Download failed: file not found at {result.file_path}')
+
   # --- Centralized filename pattern logic ---
   title = dl_request.output_filename if dl_request.output_filename else result.title
 

--- a/dl-downer/src/utils/download_dl_request.py
+++ b/dl-downer/src/utils/download_dl_request.py
@@ -1,7 +1,12 @@
+import os
+import shutil
 import time
 from loguru import logger
 from ..models.dl_request_platform import DLRequestPlatform
 from ..models.dl_request import DLRequest
+from ..models.download_result import DownloadResult
+from .apply_output_pattern import apply_output_pattern
+from .parse_filename_fields import parse_filename_fields
 
 def download_dl_request(
   dl_request: DLRequest,
@@ -9,28 +14,63 @@ def download_dl_request(
   logger.info(f'Downloading {dl_request.video_page_or_manifest_url} from {dl_request.platform} ...')
   start_time = time.time()
 
+  result: DownloadResult = None
+
   if dl_request.platform == DLRequestPlatform.VRTMAX.value:
     from ..downloaders.VRTMAX import VRTMAX_DL
-    VRTMAX_DL(dl_request)
+    result = VRTMAX_DL(dl_request)
   elif dl_request.platform == DLRequestPlatform.GOPLAY.value:
     from ..downloaders.GOPLAY import GOPLAY_DL
-    GOPLAY_DL(dl_request)
+    result = GOPLAY_DL(dl_request)
   elif dl_request.platform == DLRequestPlatform.VTMGO.value:
     from ..downloaders.VTMGO import VTMGO_DL
-    VTMGO_DL(dl_request)
+    result = VTMGO_DL(dl_request)
   elif dl_request.platform == DLRequestPlatform.STREAMZ.value:
     from ..downloaders.STREAMZ import STREAMZ_DL
-    STREAMZ_DL(dl_request)
+    result = STREAMZ_DL(dl_request)
   elif dl_request.platform == DLRequestPlatform.GENERIC_MANIFEST.value:
     from ..downloaders.GENERIC_MANIFEST import GENERIC_MANIFEST_DL
-    GENERIC_MANIFEST_DL(dl_request)
+    result = GENERIC_MANIFEST_DL(dl_request)
   elif dl_request.platform == DLRequestPlatform.YOUTUBE.value:
     from ..downloaders.YOUTUBE import YOUTUBE_DL
-    YOUTUBE_DL(dl_request)
+    result = YOUTUBE_DL(dl_request)
   else:
     logger.error(f'Unsupported platform: {dl_request.platform}')
-    # throw error for now
     raise Exception('Unsupported platform')
 
+  # --- Centralized filename pattern logic ---
+  title = dl_request.output_filename if dl_request.output_filename else result.title
+
+  # Use explicitly returned season/episode if available.
+  # Otherwise, attempt generic regex extraction from the suggested filename.
+  season = result.season
+  episode = result.episode
+  if season is None or episode is None:
+    parsed = parse_filename_fields(os.path.splitext(os.path.basename(result.suggested_filepath))[0])
+    if season is None:
+      season = parsed['season']
+    if episode is None:
+      episode = parsed['episode']
+
+  final_path = apply_output_pattern(
+    title=title,
+    platform=result.platform,
+    extension=result.extension,
+    suggested_filepath=result.suggested_filepath,
+    current_filepath=result.file_path,
+    season=season,
+    episode=episode,
+  )
+
+  # Copy + delete the file to the final location if it differs
+  # (always copy+delete instead of shutil.move — move fails across filesystems)
+  if os.path.abspath(result.file_path) != os.path.abspath(final_path):
+    os.makedirs(os.path.dirname(final_path), exist_ok=True)
+    shutil.copy2(result.file_path, final_path)
+    os.remove(result.file_path)
+    logger.info(f'Moved {result.file_path} → {final_path}')
+  else:
+    logger.debug(f'File already at final location: {final_path}')
+
   duration = time.time() - start_time
-  logger.info(f'({duration:.2f}s) Downloaded {dl_request.video_page_or_manifest_url} from {dl_request.platform} successfully!')
+  logger.info(f'({duration:.2f}s) Downloaded to {final_path}')

--- a/dl-downer/src/utils/parse_filename_fields.py
+++ b/dl-downer/src/utils/parse_filename_fields.py
@@ -1,0 +1,55 @@
+import re
+
+
+def parse_filename_fields(filename: str) -> dict:
+  '''
+  Extract title, season, and episode from a filename using regex.
+
+  Tries common patterns in order:
+    1. S01E03 / s1e3 / S01.E03 / S01A03 (Dutch)
+    2. 1x03
+    3. Season 1 Episode 3 / Seizoen 1 Aflevering 3
+
+  Returns dict with 'title', 'season', 'episode'.
+  Season/episode are zero-padded strings or None.
+  '''
+  result = {
+    'title': filename,
+    'season': None,
+    'episode': None,
+  }
+
+  # Pattern 1: S01E03, s1e3, S01.E03, S01A03
+  match = re.search(r'[.\s_-]*[Ss](\d{1,4})[.\s_-]*[EeAa](\d{1,4})', filename)
+  if match:
+    result['season'] = match.group(1).zfill(2)
+    result['episode'] = match.group(2).zfill(2)
+    result['title'] = filename[:match.start()].rstrip('.-_ ')
+    if result['title']:
+      return result
+
+  # Pattern 2: 1x03
+  match = re.search(r'[.\s_-]*(\d{1,2})x(\d{1,4})', filename)
+  if match:
+    result['season'] = match.group(1).zfill(2)
+    result['episode'] = match.group(2).zfill(2)
+    result['title'] = filename[:match.start()].rstrip('.-_ ')
+    if result['title']:
+      return result
+
+  # Pattern 3: Season/Seizoen + Episode/Aflevering/Ep
+  match = re.search(
+    r'[.\s_-]*(?:Season|Seizoen)[.\s_-]*(\d{1,4})[.\s_-]*(?:Episode|Aflevering|Ep)[.\s_-]*(\d{1,4})',
+    filename,
+    re.IGNORECASE,
+  )
+  if match:
+    result['season'] = match.group(1).zfill(2)
+    result['episode'] = match.group(2).zfill(2)
+    result['title'] = filename[:match.start()].rstrip('.-_ ')
+    if result['title']:
+      return result
+
+  # No season/episode found
+  result['title'] = filename
+  return result

--- a/dl-downer/tests/test_apply_output_pattern.py
+++ b/dl-downer/tests/test_apply_output_pattern.py
@@ -1,0 +1,374 @@
+import os
+import pytest
+from unittest.mock import patch
+
+from src.utils.apply_output_pattern import (
+  apply_output_pattern,
+  _resolve_segment,
+  _substitute_variables,
+)
+
+
+def p(*parts):
+  '''Normalize a path for cross-platform assertions.'''
+  return os.path.normpath(os.path.join(*parts))
+
+
+# ──────────────────────────────────────────────────────
+# _substitute_variables
+# ──────────────────────────────────────────────────────
+
+class TestSubstituteVariables:
+
+  def test_all_variables_resolved(self):
+    result = _substitute_variables(
+      '{title}.S{season}E{episode}',
+      {'title': 'De.Mol', 'season': '01', 'episode': '03'},
+    )
+    assert result == 'De.Mol.S01E03'
+
+  def test_missing_variable_left_as_placeholder(self):
+    result = _substitute_variables(
+      'S{season}E{episode}',
+      {'season': '01'},
+    )
+    assert result == 'S01E{episode}'
+
+  def test_no_variables(self):
+    result = _substitute_variables('literal_text', {'title': 'whatever'})
+    assert result == 'literal_text'
+
+  def test_empty_string(self):
+    result = _substitute_variables('', {'title': 'x'})
+    assert result == ''
+
+
+# ──────────────────────────────────────────────────────
+# _resolve_segment
+# ──────────────────────────────────────────────────────
+
+class TestResolveSegment:
+
+  def test_all_resolved(self):
+    variables = {'title': 'De.Mol', 'season': '01', 'episode': '03', 'extension': 'mkv'}
+    result = _resolve_segment('{title}.S{season}E{episode}.{extension}', variables)
+    assert result == 'De.Mol.S01E03.mkv'
+
+  def test_season_episode_stripped_when_missing(self):
+    variables = {'title': 'Some.Movie', 'extension': 'mkv'}
+    result = _resolve_segment('{title}.S{season}E{episode}.{extension}', variables)
+    assert result == 'Some.Movie.mkv'
+
+  def test_only_title_and_extension(self):
+    variables = {'title': 'Test', 'extension': 'mp4'}
+    result = _resolve_segment('{title}.{extension}', variables)
+    assert result == 'Test.mp4'
+
+  def test_platform_segment(self):
+    variables = {'platform': 'VRTMAX'}
+    result = _resolve_segment('{platform}', variables)
+    assert result == 'VRTMAX'
+
+  def test_entirely_unresolved(self):
+    result = _resolve_segment('{unknown}', {})
+    assert result == ''
+
+  def test_mixed_resolved_and_unresolved(self):
+    variables = {'title': 'Show', 'extension': 'mkv'}
+    result = _resolve_segment('{title}.{missing_var}.{extension}', variables)
+    assert result == 'Show.mkv'
+
+  def test_episode_only_no_season(self):
+    '''S{season}E05 still contains {season}, so the whole dot-group is stripped.'''
+    variables = {'title': 'Test', 'episode': '05', 'extension': 'mkv'}
+    result = _resolve_segment('{title}.S{season}E{episode}.{extension}', variables)
+    assert result == 'Test.mkv'
+
+
+# ──────────────────────────────────────────────────────
+# apply_output_pattern (integration tests)
+# ──────────────────────────────────────────────────────
+
+class TestApplyOutputPattern:
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_default_pattern_with_series(self):
+    result = apply_output_pattern(
+      title='De Mol',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/De.Mol.S01E03.mkv',
+      current_filepath='/downloads/VRTMAX/De.Mol.S01E03.mkv',
+      season='01',
+      episode='03',
+    )
+    assert result == p('/downloads', 'VRTMAX', 'De.Mol.S01E03.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_default_pattern_without_season_episode(self):
+    result = apply_output_pattern(
+      title='Some Movie Title',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Some.Movie.Title.mkv',
+    )
+    assert result == p('/downloads', 'VRTMAX', 'Some.Movie.Title.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_goplay_no_season_episode(self):
+    result = apply_output_pattern(
+      title='Huis Gemaakt',
+      platform='GOPLAY',
+      extension='mp4',
+      suggested_filepath='/downloads/GOPLAY/Huis.Gemaakt.mp4',
+    )
+    assert result == p('/downloads', 'GOPLAY', 'Huis.Gemaakt.mp4')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': './downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_nested_subdirectory_pattern(self):
+    result = apply_output_pattern(
+      title='De Mol',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='./downloads/VRTMAX/De.Mol.S01E03.mkv',
+      season='01',
+      episode='03',
+    )
+    assert result == p('./downloads', 'VRTMAX', 'De.Mol', 'De.Mol.S01E03.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': './downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_nested_subdirectory_pattern_movie(self):
+    result = apply_output_pattern(
+      title='A Movie',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='./downloads/VRTMAX/A.Movie.mkv',
+    )
+    assert result == p('./downloads', 'VRTMAX', 'A.Movie', 'A.Movie.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/data/media',
+    'DL_OUTPUT_PATTERN': '{title}.S{season}E{episode}.{extension}',
+  })
+  def test_flat_pattern_no_platform_folder(self):
+    result = apply_output_pattern(
+      title='Show Name',
+      platform='VTMGO',
+      extension='mkv',
+      suggested_filepath='/data/media/VTMGO/Show.Name.S02E10.mkv',
+      season='02',
+      episode='10',
+    )
+    assert result == p('/data/media', 'Show.Name.S02E10.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_special_characters_in_title(self):
+    result = apply_output_pattern(
+      title="Café & Bar: L'été",
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Cafe.En.Bar.Lete.S01E01.mkv',
+      season='01',
+      episode='01',
+    )
+    assert 'Cafe' in result
+    assert '.mkv' in result
+    assert 'S01E01' in result
+    assert '{' not in result
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_youtube_no_season(self):
+    result = apply_output_pattern(
+      title='Some YouTube Video',
+      platform='YOUTUBE',
+      extension='mkv',
+      suggested_filepath='/downloads/YOUTUBE/Some.Youtube.Video.mkv',
+    )
+    assert result == p('/downloads', 'YOUTUBE', 'Some.Youtube.Video.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.{extension}',
+  })
+  def test_simple_pattern_ignores_season_episode(self):
+    result = apply_output_pattern(
+      title='De Mol',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/De.Mol.S01E03.mkv',
+      season='01',
+      episode='03',
+    )
+    assert result == p('/downloads', 'VRTMAX', 'De.Mol.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+  }, clear=False)
+  def test_default_pattern_when_env_not_set(self):
+    env = os.environ.copy()
+    env.pop('DL_OUTPUT_PATTERN', None)
+    with patch.dict(os.environ, env, clear=True):
+      result = apply_output_pattern(
+        title='Test Show',
+        platform='VRTMAX',
+        extension='mkv',
+        suggested_filepath='/downloads/VRTMAX/Test.Show.S01E05.mkv',
+        season='01',
+        episode='05',
+      )
+      assert 'S01E05' in result
+      assert 'VRTMAX' in result
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_file_deduplication(self, tmp_path):
+    with patch.dict(os.environ, {'DOWNLOADS_FOLDER': str(tmp_path)}):
+      target_dir = tmp_path / 'VRTMAX'
+      target_dir.mkdir()
+      (target_dir / 'De.Mol.S01E03.mkv').touch()
+
+      result = apply_output_pattern(
+        title='De Mol',
+        platform='VRTMAX',
+        extension='mkv',
+        suggested_filepath='/tmp/VRTMAX/De.Mol.S01E03.mkv',
+        season='01',
+        episode='03',
+      )
+      assert 'De.Mol.S01E03-' in result
+      assert result.endswith('.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.{extension}',
+  })
+  def test_zero_padded_season_episode(self):
+    result = apply_output_pattern(
+      title='Show',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Show.S01E09.mkv',
+      season='01',
+      episode='09',
+    )
+    assert 'S01E09' in result
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': 'all/{title}.{extension}',
+  })
+  def test_custom_pattern_no_platform(self):
+    result = apply_output_pattern(
+      title='Anything',
+      platform='GOPLAY',
+      extension='mkv',
+      suggested_filepath='/downloads/GOPLAY/Anything.mkv',
+    )
+    assert result == p('/downloads', 'all', 'Anything.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.720p.{extension}',
+  })
+  def test_extra_literal_in_filename(self):
+    result = apply_output_pattern(
+      title='Show',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Show.S01E01.mkv',
+      season='01',
+      episode='01',
+    )
+    assert result == p('/downloads', 'VRTMAX', 'Show.S01E01.720p.mkv')
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}.S{season}E{episode}.720p.{extension}',
+  })
+  def test_extra_literal_without_season(self):
+    result = apply_output_pattern(
+      title='Movie',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Movie.mkv',
+    )
+    assert result == p('/downloads', 'VRTMAX', 'Movie.720p.mkv')
+
+  # ── Path traversal / security ──
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '../{title}.{extension}',
+  })
+  def test_path_traversal_blocked_dotdot(self):
+    result = apply_output_pattern(
+      title='Hack',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Hack.mkv',
+    )
+    assert result == '/downloads/VRTMAX/Hack.mkv'
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/../../etc/{title}.{extension}',
+  })
+  def test_path_traversal_blocked_nested_dotdot(self):
+    result = apply_output_pattern(
+      title='Hack',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Hack.mkv',
+    )
+    assert result == '/downloads/VRTMAX/Hack.mkv'
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{platform}/{title}..{extension}',
+  })
+  def test_dotdot_in_filename_part_blocked(self):
+    result = apply_output_pattern(
+      title='Test',
+      platform='VRTMAX',
+      extension='mkv',
+      suggested_filepath='/downloads/VRTMAX/Test.mkv',
+    )
+    assert result == '/downloads/VRTMAX/Test.mkv'
+
+  # ── Fallback ──
+
+  @patch.dict(os.environ, {
+    'DOWNLOADS_FOLDER': '/downloads',
+    'DL_OUTPUT_PATTERN': '{nonexistent_var}/{another_missing}',
+  })
+  def test_pattern_resolves_to_empty_uses_fallback(self):
+    result = apply_output_pattern(
+      title='Fallback Test',
+      platform='GOPLAY',
+      extension='mkv',
+      suggested_filepath='/downloads/GOPLAY/Fallback.Test.mkv',
+    )
+    assert result == '/downloads/GOPLAY/Fallback.Test.mkv'

--- a/dl-downer/tests/test_parse_filename_fields.py
+++ b/dl-downer/tests/test_parse_filename_fields.py
@@ -1,0 +1,128 @@
+from src.utils.parse_filename_fields import parse_filename_fields
+
+
+class TestParseFilenameFields:
+
+  # ── S##E## patterns ──
+
+  def test_standard_s01e03(self):
+    result = parse_filename_fields('De.Mol.S01E03')
+    assert result['title'] == 'De.Mol'
+    assert result['season'] == '01'
+    assert result['episode'] == '03'
+
+  def test_uppercase_s2e5(self):
+    result = parse_filename_fields('Show.S2E5.720p')
+    assert result['title'] == 'Show'
+    assert result['season'] == '02'
+    assert result['episode'] == '05'
+
+  def test_lowercase_s01e01(self):
+    result = parse_filename_fields('show.s01e01')
+    assert result['title'] == 'show'
+    assert result['season'] == '01'
+    assert result['episode'] == '01'
+
+  def test_dot_between_s_and_e(self):
+    result = parse_filename_fields('Show.S01.E03')
+    assert result['title'] == 'Show'
+    assert result['season'] == '01'
+    assert result['episode'] == '03'
+
+  def test_space_separated(self):
+    result = parse_filename_fields('Some Show S1E2')
+    assert result['title'] == 'Some Show'
+    assert result['season'] == '01'
+    assert result['episode'] == '02'
+
+  def test_dash_before_season(self):
+    result = parse_filename_fields('Show-S03E10')
+    assert result['title'] == 'Show'
+    assert result['season'] == '03'
+    assert result['episode'] == '10'
+
+  def test_zero_padded_result(self):
+    result = parse_filename_fields('X.S1E3')
+    assert result['season'] == '01'
+    assert result['episode'] == '03'
+
+  # ── Dutch S##A## format ──
+
+  def test_dutch_s_a_format(self):
+    result = parse_filename_fields('De.Mol.S01A03')
+    assert result['title'] == 'De.Mol'
+    assert result['season'] == '01'
+    assert result['episode'] == '03'
+
+  # ── 1x03 pattern ──
+
+  def test_1x03_format(self):
+    result = parse_filename_fields('Show.1x03')
+    assert result['title'] == 'Show'
+    assert result['season'] == '01'
+    assert result['episode'] == '03'
+
+  def test_2x10_format_with_dashes(self):
+    result = parse_filename_fields('Show-2x10-720p')
+    assert result['title'] == 'Show'
+    assert result['season'] == '02'
+    assert result['episode'] == '10'
+
+  # ── Written-out patterns ──
+
+  def test_season_episode_written_out(self):
+    result = parse_filename_fields('Show Season 1 Episode 3')
+    assert result['title'] == 'Show'
+    assert result['season'] == '01'
+    assert result['episode'] == '03'
+
+  def test_seizoen_aflevering(self):
+    result = parse_filename_fields('De Mol Seizoen 2 Aflevering 5')
+    assert result['title'] == 'De Mol'
+    assert result['season'] == '02'
+    assert result['episode'] == '05'
+
+  def test_season_ep_abbreviated(self):
+    result = parse_filename_fields('Show.Season.3.Ep.12')
+    assert result['title'] == 'Show'
+    assert result['season'] == '03'
+    assert result['episode'] == '12'
+
+  # ── No season/episode ──
+
+  def test_no_season_episode(self):
+    result = parse_filename_fields('Just.A.Movie.2024')
+    assert result['title'] == 'Just.A.Movie.2024'
+    assert result['season'] is None
+    assert result['episode'] is None
+
+  def test_plain_title(self):
+    result = parse_filename_fields('Documentary')
+    assert result['title'] == 'Documentary'
+    assert result['season'] is None
+    assert result['episode'] is None
+
+  def test_timestamp_filename(self):
+    result = parse_filename_fields('20240315-143022')
+    assert result['title'] == '20240315-143022'
+    assert result['season'] is None
+    assert result['episode'] is None
+
+  # ── Edge cases ──
+
+  def test_multi_digit_season_episode(self):
+    result = parse_filename_fields('Show.S12E103')
+    assert result['season'] == '12'
+    assert result['episode'] == '103'
+
+  def test_title_extraction_strips_trailing_separators(self):
+    result = parse_filename_fields('Show...S01E01')
+    assert result['title'] == 'Show'
+    assert result['season'] == '01'
+    assert result['episode'] == '01'
+
+  def test_empty_string(self):
+    result = parse_filename_fields('')
+    assert result['title'] == ''
+    assert result['season'] is None
+    assert result['episode'] is None


### PR DESCRIPTION
## Summary

This PR adds the option to control the output filepath pattern for downloaded files.
Env var example: `DL_OUTPUT_PATTERN={title_spaced}/{title}.S{season}E{episode}.{platform}.{extension}`.

All downloaders now also return an object containing metadata about the download, it is the downloader's responsibility to return as much metadata as possible (season, episode).

## Tests

Tests were generated using my dear frient Opus. I don't really feel the need to add these to the gh actions / PR checks.

## NOTE

Lets squach this PR into 1 commit, makes it easier to revert if needed.
