### PR TITLE
Fix URL construction for base URLs with subpaths

### DIFF
--- a/dl-chrome-extension/src/components/queue.tsx
+++ b/dl-chrome-extension/src/components/queue.tsx
@@ -18,7 +18,8 @@ const Queue = () => {
 
   function fetchData() {
     chrome.storage.sync.get(['token', 'url'], (data) => {
-      const reqURL = new URL('/queue', data.url || 'http://localhost:8282');
+      const base = (data.url || 'http://localhost:8282').replace(/\/?$/, '/');
+      const reqURL = new URL('queue', base);
       fetch(
         reqURL.toString(),
         {

--- a/dl-downer/src/mpd/segment_template.py
+++ b/dl-downer/src/mpd/segment_template.py
@@ -27,12 +27,12 @@ class SegmentTemplate:
     self.start_number = start_number
     self.presentation_time_offset = presentation_time_offset
     self.segments: List[Segment] = []
-  
+
   def __str__(self):
     return f'<SegmentTemplate(initialization={self.initialization}, media={self.media}, timescale={self.timescale}, start_number={self.start_number}, presentation_time_offset={self.presentation_time_offset}, segments={len(self.segments)})>'
   def __repr__(self):
     return self.__str__()
-  
+
   @staticmethod
   def from_element(element: ET.Element):
     logger.debug(f'Parsing SegmentTemplate with initialization: {element.get("initialization")}')
@@ -55,7 +55,7 @@ class SegmentTemplate:
       # sometimes the first segment does not have a start time
       elif segment_template.start_number is not None:
         current_t = segment_template.start_number
-      
+
       for segment in segments:
         dur = int(segment.get('d'))
         seg_t = None

--- a/dl-downer/src/mpd/segment_template.py
+++ b/dl-downer/src/mpd/segment_template.py
@@ -27,12 +27,12 @@ class SegmentTemplate:
     self.start_number = start_number
     self.presentation_time_offset = presentation_time_offset
     self.segments: List[Segment] = []
-
+  
   def __str__(self):
     return f'<SegmentTemplate(initialization={self.initialization}, media={self.media}, timescale={self.timescale}, start_number={self.start_number}, presentation_time_offset={self.presentation_time_offset}, segments={len(self.segments)})>'
   def __repr__(self):
     return self.__str__()
-
+  
   @staticmethod
   def from_element(element: ET.Element):
     logger.debug(f'Parsing SegmentTemplate with initialization: {element.get("initialization")}')
@@ -55,7 +55,7 @@ class SegmentTemplate:
       # sometimes the first segment does not have a start time
       elif segment_template.start_number is not None:
         current_t = segment_template.start_number
-
+      
       for segment in segments:
         dur = int(segment.get('d'))
         seg_t = None


### PR DESCRIPTION
### What's the problem?

The current code uses `new URL(path, base)` to build request URLs, but this follows the WHATWG URL standard in a way that silently drops subpaths from the base URL when there's no trailing slash.

For example, if a user has configured `http://localhost/dl-queue` as their base URL:

```js
// Current behavior
new URL('/queue', 'http://localhost/dl-queue')  // → http://localhost/queue  ❌
new URL('queue',  'http://localhost/dl-queue')  // → http://localhost/queue  ❌
```

In both cases, the `/dl-queue` part is completely ignored. This means any user running the app under a subpath gets requests sent to the wrong endpoint.

### Why does this happen?

`new URL()` treats the base URL like a file path: if there's no trailing slash, the last segment is considered a "file" and gets replaced rather than appended to. This is consistent with how relative URLs work in HTML, but it's easy to miss as a subtle gotcha.

### The fix

Normalize the base URL to always have a trailing slash before constructing the URL:

```js
const base = (data.url || 'http://localhost:8282').replace(/\/?$/, '/');
const reqURL = new URL('queue', base);

// Now it works as expected
// http://localhost/dl-queue  →  http://localhost/dl-queue/queue  ✅
// http://localhost           →  http://localhost/queue           ✅
```

### Who is affected?

- **Users with a subpath in their base URL** (e.g. `http://localhost/dl-queue`) are currently broken, requests go to the wrong URL without any error message.
- **Users with a plain host URL** (e.g. `http://localhost`) are unaffected, the fix behaves identically for them.

### Risk

Low. The change only affects how the base URL is normalized before being passed to `new URL()`. Plain host URLs produce the same result as before, and subpath URLs are corrected.