### PR TITLE
Fix URL construction for base URLs with subpaths (follow-up)

### DIFF
--- a/dl-chrome-extension/src/components/download-button/download.tsx
+++ b/dl-chrome-extension/src/components/download-button/download.tsx
@@ -1,4 +1,5 @@
 import { NotificationLevel, addNotification } from "../../notifications/notifications";
+import { buildURL } from "../../utils/url";
 
 export function downloadCurrentPage() {
   download({ url: window.location.href });
@@ -16,7 +17,7 @@ export function download(options?: {
     const quality = data.quality;
     const videoURL = options?.url || window.location.href;
 
-    const fetchUrl = new URL('/queue/add', url);
+    const fetchUrl = buildURL('queue/add', url || 'http://localhost:8282');
     console.log('Sending download request', {
       url: fetchUrl.toString(),
       token: token,

--- a/dl-chrome-extension/src/components/queue.tsx
+++ b/dl-chrome-extension/src/components/queue.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { DLRequest } from "../models/dl-request";
-import Loader from "./loader";
 import { DLRequestStatus } from "../models/dl-request-status";
+import { buildURL } from "../utils/url";
+import Loader from "./loader";
 import QueueList from "./queue-table";
 import "./queue.css";
 
@@ -18,8 +19,7 @@ const Queue = () => {
 
   function fetchData() {
     chrome.storage.sync.get(['token', 'url'], (data) => {
-      const base = (data.url || 'http://localhost:8282').replace(/\/?$/, '/');
-      const reqURL = new URL('queue', base);
+      const reqURL = buildURL('queue', data.url || 'http://localhost:8282');
       fetch(
         reqURL.toString(),
         {

--- a/dl-chrome-extension/src/utils/url.ts
+++ b/dl-chrome-extension/src/utils/url.ts
@@ -1,0 +1,4 @@
+export function buildURL(path: string, base: string): URL {
+  const normalizedBase = base.replace(/\/?$/, '/');
+  return new URL(path, normalizedBase);
+}

--- a/dl-downer/src/mpd/segment_template.py
+++ b/dl-downer/src/mpd/segment_template.py
@@ -27,12 +27,12 @@ class SegmentTemplate:
     self.start_number = start_number
     self.presentation_time_offset = presentation_time_offset
     self.segments: List[Segment] = []
-  
+
   def __str__(self):
     return f'<SegmentTemplate(initialization={self.initialization}, media={self.media}, timescale={self.timescale}, start_number={self.start_number}, presentation_time_offset={self.presentation_time_offset}, segments={len(self.segments)})>'
   def __repr__(self):
     return self.__str__()
-  
+
   @staticmethod
   def from_element(element: ET.Element):
     logger.debug(f'Parsing SegmentTemplate with initialization: {element.get("initialization")}')
@@ -55,7 +55,7 @@ class SegmentTemplate:
       # sometimes the first segment does not have a start time
       elif segment_template.start_number is not None:
         current_t = segment_template.start_number
-      
+
       for segment in segments:
         dur = int(segment.get('d'))
         seg_t = None

--- a/dl-downer/src/mpd/segment_template.py
+++ b/dl-downer/src/mpd/segment_template.py
@@ -27,12 +27,12 @@ class SegmentTemplate:
     self.start_number = start_number
     self.presentation_time_offset = presentation_time_offset
     self.segments: List[Segment] = []
-
+  
   def __str__(self):
     return f'<SegmentTemplate(initialization={self.initialization}, media={self.media}, timescale={self.timescale}, start_number={self.start_number}, presentation_time_offset={self.presentation_time_offset}, segments={len(self.segments)})>'
   def __repr__(self):
     return self.__str__()
-
+  
   @staticmethod
   def from_element(element: ET.Element):
     logger.debug(f'Parsing SegmentTemplate with initialization: {element.get("initialization")}')
@@ -55,7 +55,7 @@ class SegmentTemplate:
       # sometimes the first segment does not have a start time
       elif segment_template.start_number is not None:
         current_t = segment_template.start_number
-
+      
       for segment in segments:
         dur = int(segment.get('d'))
         seg_t = None


### PR DESCRIPTION
Sorry for the quick follow-up PR @arthur-joppart-lemon! 🙈 While testing I found the same issue in one more place:

```js
new URL('/queue/add', 'http://localhost/dl-queue')
// → http://localhost/queue/add  ❌
```

The leading slash makes it even worse here, as it unconditionally overrides the entire base path.

To avoid patching every call site individually, I extracted a small helper that normalizes the base URL once:

```ts
function buildURL(path: string, base: string): URL {
  return new URL(path, base.replace(/\/?$/, '/'));
}
```