### PR TITLE
feat: [dl-downer] remove playwright-stealth + improve bot detection prev

### DIFF
--- a/dl-downer/Dockerfile
+++ b/dl-downer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright/python:v1.42.0-jammy
+FROM mcr.microsoft.com/playwright/python:v1.52.0-jammy
 
 LABEL org.opencontainers.image.source https://github.com/BelgianNoise/dl-utils
 

--- a/dl-downer/requirements.txt
+++ b/dl-downer/requirements.txt
@@ -2,8 +2,7 @@ loguru
 requests
 protobuf>=4.25.1
 pywidevine==1.8.0
-playwright==1.42.0
-playwright_stealth==1.0.6
+playwright==1.52.0
 setuptools<81
 python-dotenv
 psycopg2-binary

--- a/dl-downer/src/utils/browser.py
+++ b/dl-downer/src/utils/browser.py
@@ -100,10 +100,11 @@ def create_playwright_page(platform: DLRequestPlatform) -> tuple[Browser, Page]:
     // Prevent detection via the Permissions API (headless returns a different state).
     const _query = window.Permissions && window.Permissions.prototype.query;
     if (_query) {
-      window.Permissions.prototype.query = (parameters) =>
-        parameters.name === 'notifications'
+      window.Permissions.prototype.query = function(parameters) {
+        return parameters.name === 'notifications'
           ? Promise.resolve({ state: Notification.permission })
-          : _query(parameters);
+          : _query.call(this, parameters);
+      };
     }
   """)
 

--- a/dl-downer/src/utils/browser.py
+++ b/dl-downer/src/utils/browser.py
@@ -2,12 +2,11 @@ import os
 from loguru import logger
 
 from playwright.sync_api import sync_playwright
-from playwright.sync_api import Browser, Page, Playwright
-from playwright_stealth import stealth_sync
+from playwright.sync_api import Browser, Page
 
 from ..models.dl_request_platform import DLRequestPlatform
 
-user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 OPR/114.0.0.0'
+user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
 playwright = sync_playwright().start()
 
 def get_storage_state_location(platform: DLRequestPlatform) -> str:
@@ -47,13 +46,65 @@ def create_playwright_page(platform: DLRequestPlatform) -> tuple[Browser, Page]:
   browser = playwright.chromium.launch(
     headless=os.getenv('HEADLESS', 'true') == 'true',
     slow_mo=200,
+    args=[
+      # Suppresses the "Chrome is being controlled by automated software" banner
+      # and removes the most commonly checked automation flag from the browser internals.
+      '--disable-blink-features=AutomationControlled',
+      # Required when running as root inside Docker containers.
+      '--no-sandbox',
+      # Hides the "Chrome is being controlled..." info bar in non-headless mode.
+      '--disable-infobars',
+      # Avoids crashes in Docker where /dev/shm is limited.
+      '--disable-dev-shm-usage',
+      # Extensions can interfere with page behaviour; disable them for consistency.
+      '--disable-extensions',
+    ],
   )
   custom_context = browser.new_context(
     user_agent=user_agent,
     locale='nl-BE',
     storage_state=get_storage_state_location(platform),
+    # Use a realistic full-HD resolution. The headless default (1280x720) is a
+    # well-known bot fingerprint that detection scripts actively check for.
+    viewport={'width': 1920, 'height': 1080},
+    screen={'width': 1920, 'height': 1080},
+    java_script_enabled=True,
+    # Match the timezone to the nl-BE locale to avoid locale/timezone mismatches,
+    # which are another signal used by bot-detection scripts.
+    timezone_id='Europe/Brussels',
   )
   page = custom_context.new_page()
-  stealth_sync(page)
+
+  # Self-contained stealth script injected before every page load.
+  # We intentionally avoid playwright_stealth (last release 1.0.6, unmaintained):
+  # its navigator.vendor getter references an `opts` closure variable that leaks
+  # out of scope, causing a ReferenceError when video players (e.g. shaka-player)
+  # read navigator.vendor — crashing the page before any network requests fire.
+  page.add_init_script("""
+    // Hide the automation flag — the most commonly checked bot signal.
+    Object.defineProperty(navigator, 'webdriver', {get: () => undefined});
+
+    // Real browsers have a non-empty plugins list; headless Chrome has none.
+    Object.defineProperty(navigator, 'plugins', {get: () => [1, 2, 3, 4, 5]});
+
+    // Align languages with the nl-BE locale set on the browser context.
+    Object.defineProperty(navigator, 'languages', {get: () => ['nl-BE', 'nl', 'en-US', 'en']});
+
+    // navigator.vendor is 'Google Inc.' in real Chrome; empty string in some headless builds.
+    Object.defineProperty(navigator, 'vendor', {get: () => 'Google Inc.'});
+
+    // window.chrome is present in real Chrome but missing in headless builds.
+    // Shaka-player and other scripts check for its existence.
+    if (!window.chrome) window.chrome = { runtime: {} };
+
+    // Prevent detection via the Permissions API (headless returns a different state).
+    const _query = window.Permissions && window.Permissions.prototype.query;
+    if (_query) {
+      window.Permissions.prototype.query = (parameters) =>
+        parameters.name === 'notifications'
+          ? Promise.resolve({ state: Notification.permission })
+          : _query(parameters);
+    }
+  """)
 
   return (browser, page)


### PR DESCRIPTION
## Summary

- **remove unmaintained playwright-stealth:** the package made changes to the browser that do not work nicely with some video players (eg shaka-player)
- **update playwright:** Now that playwright-stealth is removed, we are not stuck to an old version of playwright
- **Update user agent:** user agent is now latest stable chrome
- **Add bot detection prevention steps:** Added some playwright config + injected custom js for better bot detection prevention